### PR TITLE
テーブル幅を固定する

### DIFF
--- a/table.css
+++ b/table.css
@@ -7,6 +7,7 @@ section.table h3 {
 }
 
 table {
+    width: 100%;
     border-collapse: collapse;
     border-spacing: 0;
     border-bottom: 2px solid #333;


### PR DESCRIPTION
セル内のテキストが少ないとこうなるので、直す
<img width="697" alt="2017-09-23 18 01 53" src="https://user-images.githubusercontent.com/2641020/30771739-53087ee0-a089-11e7-8f88-8fb63f1fadde.png">

 refs #9